### PR TITLE
Update Nokogiri to fix security alert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ source "https://rubygems.org"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"
 gem "activesupport", "~> 6.1"
-gem "nokogiri", "~> 1.18.8"
+gem "nokogiri", "~> 1.18.9"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
     minitest (5.25.5)
     net-http (0.6.0)
       uri
-    nokogiri (1.18.8)
+    nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -274,7 +274,7 @@ DEPENDENCIES
   github-pages (= 232)
   jekyll-feed (= 0.17.0)
   minima (~> 2.0)
-  nokogiri (~> 1.18.8)
+  nokogiri (~> 1.18.9)
   tzinfo (~> 2.0)
   tzinfo-data
   webrick (~> 1.9)


### PR DESCRIPTION
## Summary
- bump `nokogiri` to `1.18.9`
- regenerate `Gemfile.lock`

## Testing
- `bundle exec jekyll build`
- `bundle audit check --verbose`


------
https://chatgpt.com/codex/tasks/task_b_68813e5283dc8329845832345fbb6aa2